### PR TITLE
Don't crash when preg_match returns empty array

### DIFF
--- a/includes/cf7a-antispam-flamingo.php
+++ b/includes/cf7a-antispam-flamingo.php
@@ -277,8 +277,9 @@ class CF7_AntiSpam_Flamingo {
 			foreach ( $lines as $line ) {
 				if ( substr( trim( $line ), 0, 9 ) === 'flamingo_' ) {
 					$matches = array();
-					preg_match( '/flamingo_(.*)(?=:): "\[(.*)]"/', $line, $matches );
-					$additional_settings[ $matches[1] ] = $matches[2];
+					if ( preg_match( '/flamingo_(.*)(?=:): "\[(.*)]"/', $line, $matches ) ) {
+						$additional_settings[ $matches[1] ] = $matches[2];
+					}
 				}
 			}
 


### PR DESCRIPTION
CF7 additional settings can be arbitrary strings, with constants around tags. Following are perfectly correct additional settings:
```
flamingo_email: "[user-email]"
flamingo_name: "[first-name] [last-name]"
flamingo_subject: "Message from [user-email]"
flamingo_message: "[user-message]" 
skip_mail: on
```

However, if you have such form and try to mark inbound message as spam / ham, cf7-antispam will crash with message similar to:

> Warning: Undefined array key 1 in /var/www/html/wp-content/plugins/cf7-antispam/includes/cf7a-antispam-flamingo.php on line 281 Warning: Undefined array key 2 in /var/www/html/wp-content/plugins/cf7-antispam/includes/cf7a-antispam-flamingo.php on line 281

The reason is, `flamingo_subject` line does not match provided regular expression, but code assumes that regex will always match.

With this patch, such line will be skipped.

----------

In general, there are few cases that [CF7 will consider valid](https://github.com/takayukister/contact-form-7/blob/master/includes/rest-api.php#L474), but this plugin will not (space between key and colon, unquoted value, value starting with constant string). But since plugin only ever cares about `flamingo_message`, which can reasonably be assumed to contain only variable(s) placeholder(s), I decided to apply the least intrusive fix.