### PR TITLE
Remove warning for unsafe email configuration w/o protection

### DIFF
--- a/core/CF7_AntiSpam.php
+++ b/core/CF7_AntiSpam.php
@@ -258,6 +258,7 @@ class CF7_AntiSpam {
 
 			/* It adds hidden fields to the form */
 			$this->loader->add_filter( 'wpcf7_form_hidden_fields', $plugin_frontend, 'cf7a_add_hidden_fields', 1 );
+			$this->loader->add_filter( 'wpcf7_config_validator_available_error_codes', $plugin_frontend, 'cf7a_remove_cf7_error_message', 10, 2 );
 
 			/* adds the javascript script to frontend */
 			$this->loader->add_action( 'wp_footer', $plugin_frontend, 'enqueue_scripts' );

--- a/core/CF7_AntiSpam_Frontend.php
+++ b/core/CF7_AntiSpam_Frontend.php
@@ -62,6 +62,24 @@ class CF7_AntiSpam_Frontend {
 	}
 
 	/**
+	 * Remove "unsafe email config" error messsage
+	 *
+	 * @param array  $error_codes  List of error codes.
+	 * @param object $contact_form Current contact form object.
+	 * @return array               Modified array of error codes, without "unsafe_email_without_protection".
+	 */
+	public function cf7a_remove_cf7_error_message( $error_codes, $contact_form ) {
+		// List error codes to disable here.
+		$error_codes_to_disable = array(
+			'unsafe_email_without_protection',
+		);
+
+		$error_codes = array_diff( $error_codes, $error_codes_to_disable );
+
+		return $error_codes;
+	}
+
+	/**
 	 * It takes the form elements, clones the text inputs, adds a class to the cloned inputs, and adds the cloned inputs to the form
 	 *
 	 * @param string $form_elements - The form elements html.


### PR DESCRIPTION
CF7 introduced a new validator: unsafe email configuration in CF7 version 5.8.1.

This PR removes only this warning.

As I couldn't get the code from GitHub to work, I made this PR "blind" without seeing if it is working.

And it disables this check completely if the plugin is active. Maybe this could be only triggered if the plugin is configured (not sure if it is possible to disable the plugin without deactivating - just with the settings)

Fixes #63