### PR TITLE
Update cf7a_get_real_ip to improve IP detection logic for Cloudflare and proxies

### DIFF
--- a/admin/CF7_AntiSpam_Admin_Display.php
+++ b/admin/CF7_AntiSpam_Admin_Display.php
@@ -873,13 +873,18 @@ class CF7_AntiSpam_Admin_Display {
 				);
 			}
 
+			$this->cf7a_get_debug_ip_analysis();
+
+			$this->cf7a_get_debug_info_rest_api();
+
 			if ( ! empty( $this->options['check_language'] ) ) {
 				$result = $this->cf7a_get_debug_info_geoip();
 				if ( $result ) {
 					printf(
 						'<h3 class="title"><span class="dashicons dashicons-location"></span> %s</h3>%s',
 						esc_html( $result['title'] ),
-						$result['content'] // phpcs:ignore WordPress.Security.EscapeOutput
+						// phpcs:ignore WordPress.Security.EscapeOutput
+						$result['content']
 					);
 				}
 			} else {
@@ -897,8 +902,6 @@ class CF7_AntiSpam_Admin_Display {
 					esc_html__( 'is disabled', 'cf7-antispam' )
 				);
 			}
-
-			$this->cf7a_get_debug_info_rest_api();
 
 			$this->cf7a_get_debug_info_options();
 		}
@@ -1060,6 +1063,55 @@ class CF7_AntiSpam_Admin_Display {
 					print_r( $debug_data, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 				)
 			)
+		);
+	}
+
+	/**
+	 * It returns a string containing a formatted HTML table with the IP analysis
+	 *
+	 * @return void the HTML for the IP analysis.
+	 */
+	private function cf7a_get_debug_ip_analysis() {
+		printf( '<h2 class="title">%s</h2>', esc_html__( 'IP Analysis', 'cf7-antispam' ) );
+
+		$php_ip       = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : 'unavailable';
+		$real_ip      = cf7a_get_real_ip();
+		$cf_ip        = isset( $_SERVER['HTTP_CF_CONNECTING_IP'] ) ? $_SERVER['HTTP_CF_CONNECTING_IP'] : 'unavailable';
+		$forwarded_ip = isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : 'unavailable';
+
+		printf(
+			'<table class="widefat striped" style="max-width: 600px;">
+				<thead>
+					<tr>
+						<th>%s</th>
+						<th>%s</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><strong>cf7a_get_real_ip</strong></td>
+						<td>%s</td>
+					</tr>
+					<tr>
+						<td><strong>1) HTTP_CF_CONNECTING_IP</strong></td>
+						<td>%s</td>
+					</tr>
+					<tr>
+						<td><strong>2) HTTP_X_FORWARDED_FOR</strong></td>
+						<td>%s</td>
+					</tr>
+					<tr>
+						<td><strong>3) $_SERVER["REMOTE_ADDR"]</strong></td>
+						<td>%s</td>
+					</tr>
+				</tbody>
+			</table>',
+			esc_html__( 'Variable', 'cf7-antispam' ),
+			esc_html__( 'Value', 'cf7-antispam' ),
+			esc_html( $real_ip ),
+			esc_html( $cf_ip ),
+			esc_html( $forwarded_ip ),
+			esc_html( $php_ip )
 		);
 	}
 

--- a/core/functions.php
+++ b/core/functions.php
@@ -17,32 +17,28 @@
  * @return mixed|string - The real ip address.
  */
 function cf7a_get_real_ip() {
+	// Cloudflare: Most reliable when behind Cloudflare CDN.
+	// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
+	$http_cf_connecting_ip = ! empty( $_SERVER['HTTP_CF_CONNECTING_IP'] ) ? filter_var( wp_unslash( $_SERVER['HTTP_CF_CONNECTING_IP'] ), FILTER_VALIDATE_IP ) : false;
+	if ( ! empty( $http_cf_connecting_ip ) ) {
+		return $http_cf_connecting_ip;
+	}
+
+	// X-Forwarded-For: Standard proxy header, first IP is the client.
 	// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___HTTP_X_FORWARDED_FOR__
 	$http_x_forwarded_for = ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) : false;
 	if ( ! empty( $http_x_forwarded_for ) ) {
 		return filter_var( trim( current( explode( ',', $http_x_forwarded_for ) ) ), FILTER_VALIDATE_IP );
 	}
 
-	$http_x_real_ip = ! empty( $_SERVER['HTTP_X_REAL_IP'] ) ? filter_var( wp_unslash( $_SERVER['HTTP_X_REAL_IP'] ), FILTER_VALIDATE_IP ) : false;
-	if ( ! empty( $http_x_real_ip ) ) {
-		return $http_x_real_ip;
-	}
-
+	// REMOTE_ADDR: Fallback, may be proxy IP if behind a reverse proxy.
 	// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
 	$remote_addr = ! empty( $_SERVER['REMOTE_ADDR'] ) ? filter_var( wp_unslash( $_SERVER['REMOTE_ADDR'] ), FILTER_VALIDATE_IP ) : false;
 	if ( ! empty( $remote_addr ) ) {
 		return $remote_addr;
 	}
 
-	$http_client_ip = ! empty( $_SERVER['HTTP_CLIENT_IP'] ) ? filter_var( wp_unslash( $_SERVER['HTTP_CLIENT_IP'] ), FILTER_VALIDATE_IP ) : false;
-	if ( ! empty( $http_client_ip ) ) {
-		return $http_client_ip;
-	}
-
-	$http_cf_connecting_ip = ! empty( $_SERVER['HTTP_CF_CONNECTING_IP'] ) ? filter_var( wp_unslash( $_SERVER['HTTP_CF_CONNECTING_IP'] ), FILTER_VALIDATE_IP ) : false;
-	if ( ! empty( $http_cf_connecting_ip ) ) {
-		return $http_cf_connecting_ip;
-	}
+	return '';
 }
 
 function cf7a_strip_weight( $str ) {

--- a/tests/PhpUnit/Tests/CF7_AntiSpam_FiltersTest.php
+++ b/tests/PhpUnit/Tests/CF7_AntiSpam_FiltersTest.php
@@ -375,29 +375,6 @@ class CF7_AntiSpam_FiltersTest extends TestCase {
 		$this->assertEquals( 0, $result['spam_score'] );
 	}
 
-	public function test_filter_ip_blacklist_history_stops_infinite_increment() {
-		// Arrange
-		$data = $this->base_spam_data;
-		$data['options']['max_attempts'] = 5;
-		$data['remote_ip'] = '100.100.100.100';
-
-		// Seed the DB with an IP already at the threshold
-		// cf7a_add_to_blacklist is an instance method
-		$blacklist = new CF7_Antispam_Blacklist();
-		$blacklist->cf7a_add_to_blacklist( '100.100.100.100', 5 );
-
-		// Act
-		$result = $this->filters->filter_ip_blacklist_history( $data );
-
-		// Clean up DB
-		CF7_Antispam_Blacklist::cf7a_unban_by_ip( '100.100.100.100' );
-
-		// Assert
-		$this->assertTrue( $result['is_spam'], 'Should be marked as spam because it is blocklisted' );
-		$this->assertEquals( 0, $result['spam_score'], 'Spam score should NOT increment if already at max attempts (infinite ban fix)' );
-		$this->assertEquals( 5, $result['reasons']['blocklisted'], 'Reason should match current status' );
-	}
-
 	public function test_filter_ip_blacklist_history_respects_threshold() {
 		// Arrange
 		$data = $this->base_spam_data;

--- a/tests/PhpUnit/Tests/CF7_AntiSpam_FiltersTest.php
+++ b/tests/PhpUnit/Tests/CF7_AntiSpam_FiltersTest.php
@@ -4,6 +4,8 @@ namespace CF7_AntiSpam\Tests\PhpUnit\Tests;
 
 use CF7_AntiSpam\Core\CF7_AntiSpam;
 use CF7_AntiSpam\Core\CF7_AntiSpam_Filters;
+use CF7_AntiSpam\Core\CF7_Antispam_Blacklist;
+use CF7_AntiSpam\Engine\CF7_AntiSpam_Activator;
 use PHPUnit\Framework\TestCase;
 
 class CF7_AntiSpam_FiltersTest extends TestCase {
@@ -23,6 +25,9 @@ class CF7_AntiSpam_FiltersTest extends TestCase {
 	 */
 	protected function setUp(): void {
 		parent::setUp();
+
+		// Ensure tables exist
+		CF7_AntiSpam_Activator::install();
 
 		$this->filters = new CF7_AntiSpam_Filters();
 
@@ -368,5 +373,87 @@ class CF7_AntiSpam_FiltersTest extends TestCase {
 
 		// Assert
 		$this->assertEquals( 0, $result['spam_score'] );
+	}
+
+	public function test_filter_ip_blacklist_history_stops_infinite_increment() {
+		// Arrange
+		$data = $this->base_spam_data;
+		$data['options']['max_attempts'] = 5;
+		$data['remote_ip'] = '100.100.100.100';
+
+		// Seed the DB with an IP already at the threshold
+		// cf7a_add_to_blacklist is an instance method
+		$blacklist = new CF7_Antispam_Blacklist();
+		$blacklist->cf7a_add_to_blacklist( '100.100.100.100', 5 );
+
+		// Act
+		$result = $this->filters->filter_ip_blacklist_history( $data );
+
+		// Clean up DB
+		CF7_Antispam_Blacklist::cf7a_unban_by_ip( '100.100.100.100' );
+
+		// Assert
+		$this->assertTrue( $result['is_spam'], 'Should be marked as spam because it is blocklisted' );
+		$this->assertEquals( 0, $result['spam_score'], 'Spam score should NOT increment if already at max attempts (infinite ban fix)' );
+		$this->assertEquals( 5, $result['reasons']['blocklisted'], 'Reason should match current status' );
+	}
+
+	public function test_filter_ip_blacklist_history_respects_threshold() {
+		// Arrange
+		$data = $this->base_spam_data;
+		$data['options']['max_attempts'] = 3;
+		$data['remote_ip'] = '100.100.100.101';
+		$blacklist = new CF7_Antispam_Blacklist();
+
+		// Case 1: Status 1 (Below Threshold)
+		$blacklist->cf7a_add_to_blacklist( '100.100.100.101', 1 );
+		$result = $this->filters->filter_ip_blacklist_history( $data );
+		$this->assertFalse( $result['is_spam'], 'Status 1 should NOT be spam when max is 3' );
+		$this->assertEquals( 0, $result['spam_score'] );
+
+		// Case 2: Status 2 (Below Threshold)
+		$blacklist->cf7a_add_to_blacklist( '100.100.100.101', 2 );
+		$result = $this->filters->filter_ip_blacklist_history( $data );
+		$this->assertFalse( $result['is_spam'], 'Status 2 should NOT be spam when max is 3' );
+
+		// Case 3: Status 3 (At Threshold)
+		$blacklist->cf7a_add_to_blacklist( '100.100.100.101', 3 );
+		$result = $this->filters->filter_ip_blacklist_history( $data );
+		$this->assertTrue( $result['is_spam'], 'Status 3 SHOULD be spam when max is 3' );
+		$this->assertEquals( 3, $result['reasons']['blocklisted'] );
+
+		// Case 4: Status 5 (Above Threshold)
+		$blacklist->cf7a_add_to_blacklist( '100.100.100.101', 5 );
+		$result = $this->filters->filter_ip_blacklist_history( $data );
+		$this->assertTrue( $result['is_spam'], 'Status 5 SHOULD be spam when max is 3' );
+
+		// Clean up
+		CF7_Antispam_Blacklist::cf7a_unban_by_ip( '100.100.100.101' );
+	}
+
+	public function test_filter_ip_blacklist_history_does_not_affect_other_ips() {
+		// Arrange
+		$blacklist = new CF7_Antispam_Blacklist();
+
+		// Ban IP 100.100.100.101 with status 5 (above max_attempts 3)
+		$data = $this->base_spam_data;
+		$data['options']['max_attempts'] = 3;
+		$blacklist->cf7a_add_to_blacklist( '100.100.100.101', 5 );
+
+		// Act: Check 100.100.100.101 (should be banned)
+		$data['remote_ip'] = '100.100.100.101';
+		$result_banned = $this->filters->filter_ip_blacklist_history( $data );
+
+		// Act: Check 100.100.100.102 (should NOT be banned)
+		$data['remote_ip'] = '100.100.100.102';
+		$result_not_banned = $this->filters->filter_ip_blacklist_history( $data );
+
+		// Clean up
+		CF7_Antispam_Blacklist::cf7a_unban_by_ip( '100.100.100.101' );
+
+		// Assert
+		$this->assertTrue( $result_banned['is_spam'], 'IP 100.100.100.101 should be banned' );
+		$this->assertFalse( $result_not_banned['is_spam'], 'IP 100.100.100.102 should NOT be banned' );
+		$this->assertEquals( 0, $result_not_banned['spam_score'], 'Spam score for 100.100.100.102 should be 0' );
 	}
 }


### PR DESCRIPTION
This PR updates the cf7a_get_real_ip logic to improve the reliability of IP detection, specifically regarding Cloudflare and other proxies.

Changes
Removed support for HTTP_X_REAL_IP and HTTP_CLIENT_IP.

Reasoning
These headers are non-standard and pose a security risk due to their low reliability. Unless a reverse proxy (like a specifically configured Nginx) explicitly overwrites these headers with a verified upstream IP, they can be easily spoofed by the client.

By removing them, we ensure the plugin relies on more secure and standard methods for IP resolution, reducing the risk of bypassing bans via header manipulation.