### PR TITLE
0.7.3 c

### DIFF
--- a/admin/CF7_AntiSpam_Admin_Customizations.php
+++ b/admin/CF7_AntiSpam_Admin_Customizations.php
@@ -53,7 +53,7 @@ class CF7_AntiSpam_Admin_Customizations {
 	 */
 	public function __construct() {
 		if ( ! current_user_can( 'manage_options' ) ) {
-			exit();
+			return;
 		}
 
 		/* the plugin options */

--- a/core/CF7_Antispam_Blocklist.php
+++ b/core/CF7_Antispam_Blocklist.php
@@ -64,7 +64,9 @@ class CF7_Antispam_Blocklist {
 			if ( $ip_row ) {
 				// if the ip is in the blocklist, update the status
 				$status = isset( $ip_row->status ) ? floatval( $ip_row->status ) + floatval( $spam_score ) : 1;
-
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
+				$meta             = ! empty( $ip_row->meta ) ? unserialize( $ip_row->meta ) : array();
+				$previous_reasons = ! empty( $meta ) && ! empty( $meta['reason'] ) ? $meta['reason'] : array();
 			} else {
 				// if the ip is not in the blocklist, add it and initialize the status
 				$status = floatval( $spam_score );
@@ -79,8 +81,9 @@ class CF7_Antispam_Blocklist {
 					// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 					'meta'   => serialize(
 						array(
-							'reason' => $reason,
-							'meta'   => null,
+							'reason' => ! empty( $previous_reasons )
+								? array_merge( $previous_reasons, $reason )
+								: $reason,
 						)
 					),
 				),

--- a/core/functions.php
+++ b/core/functions.php
@@ -350,11 +350,11 @@ function cf7a_format_status( $rank ) {
  * @param array $arr - the array of reasons to ban.
  * @param bool  $is_html - true to return an HTML string.
  *
- * @return false|string Compress arrays into "key:value; " pair
+ * @return string Compress arrays into "key:value; " pair
  */
-function cf7a_compress_array( $arr, $is_html = false ) {
+function cf7a_compress_array( array $arr, bool $is_html = false ): string {
 	if ( ! is_array( $arr ) ) {
-		return false;
+		return '';
 	}
 	$is_html = intval( $is_html );
 


### PR DESCRIPTION
Some fixes:
- update cf7a_compress_array to use type hints and ensure consistent return types
- every time an IP address is banned, its spam log is updated rather than rewritten, making it possible to know the reason even after some time has passed (or multiple bans).