### PR TITLE
The sandbox attribute allow-scripts

### DIFF
--- a/src/frontend/tests.ts
+++ b/src/frontend/tests.ts
@@ -234,7 +234,10 @@ export function setupCanvasTest(hiddenInputsContainer: HTMLElement): void {
 	testCanvasIframe[3] = document.createElement('iframe');
 	testCanvasIframe[3].id = 'canvas3-iframe';
 	testCanvasIframe[3].className = 'canvased';
-	testCanvasIframe[3].setAttribute('sandbox', 'allow-same-origin');
+	testCanvasIframe[3].setAttribute(
+		'sandbox',
+		'allow-same-origin allow-scripts'
+	);
 	testCanvas[3].append(testCanvasIframe[3]);
 
 	testCanvas[4] = document.createElement('div');
@@ -242,7 +245,10 @@ export function setupCanvasTest(hiddenInputsContainer: HTMLElement): void {
 	testCanvasIframe[4] = document.createElement('iframe');
 	testCanvasIframe[4].id = 'canvas4-iframe';
 	testCanvasIframe[4].className = 'canvased';
-	testCanvasIframe[4].setAttribute('sandbox', 'allow-same-origin');
+	testCanvasIframe[4].setAttribute(
+		'sandbox',
+		'allow-same-origin allow-scripts'
+	);
 	testCanvas[4].append(testCanvasIframe[4]);
 
 	testCanvas[5] = document.createElement('div');


### PR DESCRIPTION
without the allow-scripts value prevents the browser from executing any JavaScript code within that iframe (even if it is a dynamically created about:blank page)

cc [@oceandigitals](https://profiles.wordpress.org/oceandigitals/)