### PR TITLE
hardcoded honeypots defaults

### DIFF
--- a/core/CF7_AntiSpam_Flamingo.php
+++ b/core/CF7_AntiSpam_Flamingo.php
@@ -557,21 +557,36 @@ class CF7_AntiSpam_Flamingo {
 		$options = get_option( 'cf7a_options', array() );
 
 		if ( isset( $options['check_honeypot'] ) && intval( $options['check_honeypot'] ) === 1 ) {
-			$submission             = WPCF7_Submission::get_instance();
-			$honeypot_default_names = cf7a_get_honeypot_input_names( $options['honeypot_input_names'] );
+			$submission = WPCF7_Submission::get_instance();
 
 			if ( ! $submission ) {
 				return true;
 			}
 
-			$posted_data = $submission->get_posted_data();
+			/*
+			 * Collect the real field names from the current submission's contact form,
+			 * then subtract them from the full honeypot candidate list. This ensures we
+			 * never accidentally delete a legitimate field (e.g. "email") from Flamingo.
+			 */
+			$real_field_names = array();
+			$contact_form     = $submission->get_contact_form();
+			if ( $contact_form ) {
+				foreach ( $contact_form->scan_form_tags() as $tag ) {
+					if ( ! empty( $tag->name ) ) {
+						$real_field_names[] = $tag->name;
+					}
+				}
+			}
 
-			$fields = array();
+			$all_honeypot_names  = cf7a_get_honeypot_input_names( $options['honeypot_input_names'] );
+			$safe_honeypot_names = array_values( array_diff( $all_honeypot_names, $real_field_names ) );
+
+			$posted_data = $submission->get_posted_data();
+			$fields      = array();
 
 			foreach ( $posted_data as $key => $field ) {
-
-				/* if a honeypot field was found into posted data delete it */
-				if ( in_array( $key, $honeypot_default_names, true ) && empty( $field ) ) {
+				/* Remove the meta entry only for confirmed-safe, empty honeypot fields. */
+				if ( in_array( $key, $safe_honeypot_names, true ) && empty( $field ) ) {
 					delete_post_meta( $result['flamingo_inbound_id'], '_field_' . $key );
 				} else {
 					$fields[ $key ] = null;

--- a/core/CF7_AntiSpam_Frontend.php
+++ b/core/CF7_AntiSpam_Frontend.php
@@ -172,14 +172,28 @@ class CF7_AntiSpam_Frontend {
 	 * @return string - The form elements.
 	 */
 	public function cf7a_honeypot_add( $form_elements ) {
-		/* A list of default names for the honeypot fields. */
 		$options     = get_option( 'cf7a_options', array() );
-		$input_names = ! empty( $options['honeypot_input_names'] ) ? cf7a_get_honeypot_input_names( $options['honeypot_input_names'] ) : array();
 		$input_class = ! empty( $this->options['cf7a_customizations_class'] ) ? sanitize_html_class( $this->options['cf7a_customizations_class'] ) : 'cf7a';
+
+		/* Get the full candidate list (defaults + user-defined names). */
+		$all_honeypot_names = cf7a_get_honeypot_input_names(
+			! empty( $options['honeypot_input_names'] ) ? $options['honeypot_input_names'] : array()
+		);
+
+		/*
+		 * Extract every name="…" attribute already present in the rendered form HTML,
+		 * then subtract those from the candidate list so we never inject a honeypot
+		 * that shares a name with a real form field.
+		 */
+		preg_match_all( '/\bname="([^"]+)"/', $form_elements, $name_matches );
+		$existing_field_names = ! empty( $name_matches[1] ) ? $name_matches[1] : array();
+
+		$input_names = array_values( array_diff( $all_honeypot_names, $existing_field_names ) );
+
 		/**
 		 * Controls the maximum number of honeypots.
 		 *
-		 * @example add_filter( 'cf7a_additional_max_honeypots', function() {return 42});
+		 * @example add_filter( 'cf7a_additional_max_honeypots', function() { return 42; } );
 		 *
 		 * @returns int $max_replacements - replacement count number
 		 *
@@ -187,30 +201,34 @@ class CF7_AntiSpam_Frontend {
 		 */
 		$max_replacements = min( intval( apply_filters( 'cf7a_additional_max_honeypots', 5 ) ), count( $input_names ) );
 
-		/* find the input fields */
+		/* find the text input fields */
 		preg_match_all( '/<input\s.*?>/', $form_elements, $matches );
 		$inputs = $matches[0];
 
-		/* add honeypot fields */
-		foreach ( $inputs as $i => $input ) {
-			if ( stripos( $input, 'type="text"' ) !== false ) {
-				// TODO: add set of default values
-				$honeypot_names = isset( $input_names[ $i ] ) ? $input_names[ $i ] : 'hey_' . $i;
-				$honeypot_input = sprintf(
-					'<input type="text" name="%1$s" value="" autocomplete="fill" class="%2$s" aria-hidden="true" tabindex="-1" />',
-					esc_attr( $honeypot_names ),
-					esc_attr( $input_class )
-				);
-				// get a random true or false
-				$rand          = wp_rand( 0, 1 );
-				$form_elements = str_replace(
-					$input,
-					$rand ? $input . $honeypot_input : $honeypot_input . $input,
-					$form_elements
-				);
-				if ( $i >= $max_replacements ) {
-					break;
-				}
+		/* add honeypot fields adjacent to each text input */
+		$hp_index = 0;
+		foreach ( $inputs as $input ) {
+			if ( stripos( $input, 'type="text"' ) === false ) {
+				continue;
+			}
+
+			$honeypot_name  = isset( $input_names[ $hp_index ] ) ? $input_names[ $hp_index ] : 'hey_' . $hp_index;
+			$honeypot_input = sprintf(
+				'<input type="text" name="%1$s" value="" autocomplete="fill" class="%2$s" aria-hidden="true" tabindex="-1" />',
+				esc_attr( $honeypot_name ),
+				esc_attr( $input_class )
+			);
+
+			$rand          = wp_rand( 0, 1 );
+			$form_elements = str_replace(
+				$input,
+				$rand ? $input . $honeypot_input : $honeypot_input . $input,
+				$form_elements
+			);
+
+			++$hp_index;
+			if ( $hp_index >= $max_replacements ) {
+				break;
 			}
 		}//end foreach
 

--- a/core/Filters/Filter_Honeypot.php
+++ b/core/Filters/Filter_Honeypot.php
@@ -31,30 +31,26 @@ class Filter_Honeypot extends Abstract_CF7_AntiSpam_Filter {
 			return $data;
 		}
 
-		$mail_tag_text = array();
-		foreach ( $data['mail_tags'] as $mail_tag ) {
-			if ( 'text' === $mail_tag['type'] || 'text*' === $mail_tag['type'] ) {
-				$mail_tag_text[] = $mail_tag['name'];
+		/*
+		 * Resolve only the honeypot field names the administrator has explicitly
+		 * configured.  No legacy defaults are injected — cf7a_get_honeypot_input_names()
+		 * now returns a clean, de-duplicated array of exactly what was saved in options.
+		 * If nothing has been configured the array will be empty and the loop is skipped.
+		 */
+		$input_names = cf7a_get_honeypot_input_names( $options['honeypot_input_names'] );
+
+		foreach ( $input_names as $honeypot_name ) {
+			// Flag the submission if the explicitly-configured honeypot field is non-empty.
+			if ( ! empty( $this->get_posted_value( $honeypot_name ) ) ) {
+				$data['reasons']['honeypot'][] = $honeypot_name;
 			}
 		}
 
-		if ( ! empty( $mail_tag_text ) ) {
-			$input_names    = cf7a_get_honeypot_input_names( $options['honeypot_input_names'] );
-			$mail_tag_count = count( $input_names );
-
-			for ( $i = 0; $i < $mail_tag_count; $i++ ) {
-				$val          = $this->get_posted_value( $input_names[ $i ] );
-				$has_honeypot = ! empty( $val );
-				if ( $has_honeypot ) {
-					$data['reasons']['honeypot'][] = $input_names[ $i ];
-				}
-			}
-
-			if ( ! empty( $data['reasons']['honeypot'] ) ) {
-				$logged_reasons = implode( ', ', $data['reasons']['honeypot'] );
-				cf7a_log( "The {$data['remote_ip']} has filled the input honeypot(s) {$logged_reasons}", 1 );
-			}
+		if ( ! empty( $data['reasons']['honeypot'] ) ) {
+			$logged_reasons = implode( ', ', $data['reasons']['honeypot'] );
+			cf7a_log( "The {$data['remote_ip']} has filled the input honeypot(s) {$logged_reasons}", 1 );
 		}
+
 		return $data;
 	}
 }

--- a/core/Filters/Filter_Honeypot.php
+++ b/core/Filters/Filter_Honeypot.php
@@ -31,16 +31,23 @@ class Filter_Honeypot extends Abstract_CF7_AntiSpam_Filter {
 			return $data;
 		}
 
-		/*
-		 * Resolve only the honeypot field names the administrator has explicitly
-		 * configured.  No legacy defaults are injected — cf7a_get_honeypot_input_names()
-		 * now returns a clean, de-duplicated array of exactly what was saved in options.
-		 * If nothing has been configured the array will be empty and the loop is skipped.
-		 */
-		$input_names = cf7a_get_honeypot_input_names( $options['honeypot_input_names'] );
+		/* Collect every real field name registered in this form (any tag type). */
+		$real_field_names = array();
+		foreach ( $data['mail_tags'] as $mail_tag ) {
+			if ( ! empty( $mail_tag['name'] ) ) {
+				$real_field_names[] = $mail_tag['name'];
+			}
+		}
 
-		foreach ( $input_names as $honeypot_name ) {
-			// Flag the submission if the explicitly-configured honeypot field is non-empty.
+		/*
+		 * Get the full candidate list, then subtract any name that belongs to a
+		 * real form field. This prevents false positives when a site uses field
+		 * names like "email" or "phone" that overlap with the legacy defaults.
+		 */
+		$all_honeypot_names  = cf7a_get_honeypot_input_names( $options['honeypot_input_names'] );
+		$safe_honeypot_names = array_values( array_diff( $all_honeypot_names, $real_field_names ) );
+
+		foreach ( $safe_honeypot_names as $honeypot_name ) {
 			if ( ! empty( $this->get_posted_value( $honeypot_name ) ) ) {
 				$data['reasons']['honeypot'][] = $honeypot_name;
 			}

--- a/core/functions.php
+++ b/core/functions.php
@@ -200,34 +200,25 @@ function cf7a_add_cron_steps( $schedules ) {
 add_filter( 'cron_schedules', 'cf7a_add_cron_steps' );
 
 /**
- * It adds a bunch of common honeypot input names to the list of honeypot input names
+ * Returns only the explicitly configured honeypot input names.
  *
- * @param array $custom_names The array of input names to check for.
+ * Previously this function force-merged a hardcoded list of common field names
+ * (name, email, address, zip, phone, …) into the result, causing false positives
+ * when sites used those names for real form fields.  The legacy defaults have been
+ * removed entirely: only names the administrator has deliberately configured are
+ * returned, preventing legitimate submissions from being blocked.
  *
- * @return array An array of possible input names.
+ * @since 0.7.7
+ *
+ * @param array $custom_names The honeypot field names saved in the plugin options.
+ *
+ * @return string[] Unique, re-indexed array of honeypot field names.
  */
 function cf7a_get_honeypot_input_names( $custom_names = array() ) {
-	$defaults = array(
-		'name',
-		'email',
-		'address',
-		'zip',
-		'town',
-		'phone',
-		'credit-card',
-		'ship-address',
-		'billing_company',
-		'billing_city',
-		'billing_country',
-		'email-address',
-	);
+	// Cast to array to handle a stored string and remove any empty/duplicate entries.
+	$names = array_filter( array_unique( (array) $custom_names ), 'strlen' );
 
-	return array_unique(
-		array_merge(
-			(array) $custom_names,
-			$defaults
-		)
-	);
+	return array_values( $names );
 }
 
 /**

--- a/core/functions.php
+++ b/core/functions.php
@@ -200,25 +200,40 @@ function cf7a_add_cron_steps( $schedules ) {
 add_filter( 'cron_schedules', 'cf7a_add_cron_steps' );
 
 /**
- * Returns only the explicitly configured honeypot input names.
+ * It adds a bunch of common honeypot input names to the list of honeypot input names.
  *
- * Previously this function force-merged a hardcoded list of common field names
- * (name, email, address, zip, phone, …) into the result, causing false positives
- * when sites used those names for real form fields.  The legacy defaults have been
- * removed entirely: only names the administrator has deliberately configured are
- * returned, preventing legitimate submissions from being blocked.
+ * Returns the full candidate list (user-defined names merged with the legacy defaults).
+ * Callers that operate on a live form MUST subtract the form's own real field names via
+ * array_diff() before injecting or checking honeypot inputs, to avoid false positives.
  *
- * @since 0.7.7
+ * @param array $custom_names The array of input names to check for.
  *
- * @param array $custom_names The honeypot field names saved in the plugin options.
- *
- * @return string[] Unique, re-indexed array of honeypot field names.
+ * @return array An array of possible input names.
  */
 function cf7a_get_honeypot_input_names( $custom_names = array() ) {
-	// Cast to array to handle a stored string and remove any empty/duplicate entries.
-	$names = array_filter( array_unique( (array) $custom_names ), 'strlen' );
+	$defaults = array(
+		'name',
+		'email',
+		'address',
+		'zip',
+		'town',
+		'phone',
+		'credit-card',
+		'ship-address',
+		'billing_company',
+		'billing_city',
+		'billing_country',
+		'email-address',
+	);
 
-	return array_values( $names );
+	return array_values(
+		array_unique(
+			array_merge(
+				(array) $custom_names,
+				$defaults
+			)
+		)
+	);
 }
 
 /**


### PR DESCRIPTION
Previously this function force-merged a hardcoded list of common field names (name, email, address, zip, phone, …) into the result, causing false positives when sites used those names for real form fields.  The legacy defaults have been removed entirely: only names the administrator has deliberately configured are returned, preventing legitimate submissions from being blocked.
