### PR TITLE
Antispam filters filter

### DIFF
--- a/core/Abstract_CF7_AntiSpam_Filter.php
+++ b/core/Abstract_CF7_AntiSpam_Filter.php
@@ -18,6 +18,15 @@ namespace CF7_AntiSpam\Core;
 abstract class Abstract_CF7_AntiSpam_Filter {
 
 	/**
+	 * The slug key that identifies this filter within the native_filters array.
+	 * Injected by CF7_AntiSpam_Filters::__construct() after instantiation.
+	 * Used by check() to honour the cf7a_active_filters opt-out mechanism.
+	 *
+	 * @var string
+	 */
+	public $filter_key;
+
+	/**
 	 * Run the filter check.
 	 *
 	 * @param array $spam_data The spam data context.
@@ -25,6 +34,13 @@ abstract class Abstract_CF7_AntiSpam_Filter {
 	 * @return array The updated spam data context.
 	 */
 	public function check( array $spam_data ): array {
+		// If the developer removed this filter via the cf7a_active_filters hook, skip processing.
+		if ( ! empty( $this->filter_key ) && isset( $spam_data['active_filters'] ) ) {
+			if ( ! isset( $spam_data['active_filters'][ $this->filter_key ] ) ) {
+				return $spam_data;
+			}
+		}
+
 		if ( isset( $spam_data['is_allowlisted'] ) && $spam_data['is_allowlisted'] ) {
 			return $spam_data;
 		}

--- a/core/CF7_AntiSpam_Filters.php
+++ b/core/CF7_AntiSpam_Filters.php
@@ -41,8 +41,19 @@ use WPCF7_Submission;
 class CF7_AntiSpam_Filters {
 
 	/**
+	 * Associative array of instantiated native filter objects, keyed by their slug.
+	 * Populated in __construct() so filters can be referenced and selectively
+	 * disabled at submission-time via the cf7a_active_filters hook.
+	 *
+	 * @var array
+	 */
+	public $native_filters = array();
+
+	/**
 	 * CF7_AntiSpam_Filters constructor.
-	 * Registers the individual spam checks to the custom filter hook.
+	 * Instantiates all native spam-check filters, stores them in $native_filters
+	 * (keyed by slug), injects each instance's own key, and registers the
+	 * cf7a_spam_check_chain hooks with their original priorities.
 	 *
 	 * @param bool $register_hooks Whether to register the default hooks.
 	 */
@@ -50,32 +61,65 @@ class CF7_AntiSpam_Filters {
 		if ( ! $register_hooks ) {
 			return;
 		}
-		// Priority 5: Allowlist checks (should run first to stop processing if safe)
-		add_filter( 'cf7a_spam_check_chain', array( new Filter_IP_Allowlist(), 'check' ), 5 );
+
+		// Instantiate every native filter and store it under a stable slug key.
+		$this->native_filters = array(
+			// Priority 5 – runs first
+			'ip_allowlist'           => new Filter_IP_Allowlist(),
+
+			// Priority 10 – standard checks
+			'empty_ip'               => new Filter_Empty_IP(),
+			'bad_ip'                 => new Filter_Bad_IP(),
+			'ip_blocklist_history'   => new Filter_IP_Blocklist_History(),
+			'honeyform'              => new Filter_Honeyform(),
+			'referrer_protocol'      => new Filter_Referrer_Protocol(),
+			'plugin_version'         => new Filter_Plugin_Version(),
+			'high_entropy'           => new Filter_High_Entropy(),
+			'bot_fingerprint'        => new Filter_Bot_Fingerprint(),
+			'bot_fingerprint_extras' => new Filter_Bot_Fingerprint_Extras(),
+			'language'               => new Filter_Language(),
+			'geoip'                  => new Filter_Geoip(),
+			'time_submission'        => new Filter_Time_Submission(),
+			'bad_email_strings'      => new Filter_Bad_Email_Strings(),
+			'user_agent'             => new Filter_User_Agent(),
+			'bad_words'              => new Filter_Bad_Words(),
+			'dnsbl'                  => new Filter_DNSBL(),
+			'honeypot'               => new Filter_Honeypot(),
+
+			// Priority 20 – Bayesian filter (runs last)
+			'b8'                     => new Filter_B8_Bayesian(),
+		);
+
+		// Inject each filter's own slug so it can identify itself at check-time.
+		foreach ( $this->native_filters as $key => $instance ) {
+			$instance->filter_key = $key;
+		}
+
+		// Register hooks – preserve original priorities exactly.
+		// Priority 5: Allowlist (must run first to short-circuit remaining checks)
+		add_filter( 'cf7a_spam_check_chain', array( $this->native_filters['ip_allowlist'], 'check' ), 5 );
 
 		// Priority 10: Standard checks
-		add_filter( 'cf7a_spam_check_chain', array( new Filter_Empty_IP(), 'check' ), 10 );
-		add_filter( 'cf7a_spam_check_chain', array( new Filter_Bad_IP(), 'check' ), 10 );
-		add_filter( 'cf7a_spam_check_chain', array( new Filter_IP_Blocklist_History(), 'check' ), 10 );
-		add_filter( 'cf7a_spam_check_chain', array( new Filter_Honeyform(), 'check' ), 10 );
-
-		// Checks that originally ran only if score < 1 (See logic inside methods)
-		add_filter( 'cf7a_spam_check_chain', array( new Filter_Referrer_Protocol(), 'check' ), 10 );
-		add_filter( 'cf7a_spam_check_chain', array( new Filter_Plugin_Version(), 'check' ), 10 );
-		add_filter( 'cf7a_spam_check_chain', array( new Filter_High_Entropy(), 'check' ), 10 );
-		add_filter( 'cf7a_spam_check_chain', array( new Filter_Bot_Fingerprint(), 'check' ), 10 );
-		add_filter( 'cf7a_spam_check_chain', array( new Filter_Bot_Fingerprint_Extras(), 'check' ), 10 );
-		add_filter( 'cf7a_spam_check_chain', array( new Filter_Language(), 'check' ), 10 );
-		add_filter( 'cf7a_spam_check_chain', array( new Filter_Geoip(), 'check' ), 10 );
-		add_filter( 'cf7a_spam_check_chain', array( new Filter_Time_Submission(), 'check' ), 10 );
-		add_filter( 'cf7a_spam_check_chain', array( new Filter_Bad_Email_Strings(), 'check' ), 10 );
-		add_filter( 'cf7a_spam_check_chain', array( new Filter_User_Agent(), 'check' ), 10 );
-		add_filter( 'cf7a_spam_check_chain', array( new Filter_Bad_Words(), 'check' ), 10 );
-		add_filter( 'cf7a_spam_check_chain', array( new Filter_DNSBL(), 'check' ), 10 );
-		add_filter( 'cf7a_spam_check_chain', array( new Filter_Honeypot(), 'check' ), 10 );
+		add_filter( 'cf7a_spam_check_chain', array( $this->native_filters['empty_ip'], 'check' ), 10 );
+		add_filter( 'cf7a_spam_check_chain', array( $this->native_filters['bad_ip'], 'check' ), 10 );
+		add_filter( 'cf7a_spam_check_chain', array( $this->native_filters['ip_blocklist_history'], 'check' ), 10 );
+		add_filter( 'cf7a_spam_check_chain', array( $this->native_filters['honeyform'], 'check' ), 10 );
+		add_filter( 'cf7a_spam_check_chain', array( $this->native_filters['referrer_protocol'], 'check' ), 10 );
+		add_filter( 'cf7a_spam_check_chain', array( $this->native_filters['plugin_version'], 'check' ), 10 );
+		add_filter( 'cf7a_spam_check_chain', array( $this->native_filters['high_entropy'], 'check' ), 10 );
+		add_filter( 'cf7a_spam_check_chain', array( $this->native_filters['bot_fingerprint'], 'check' ), 10 );
+		add_filter( 'cf7a_spam_check_chain', array( $this->native_filters['bot_fingerprint_extras'], 'check' ), 10 );
+		add_filter( 'cf7a_spam_check_chain', array( $this->native_filters['language'], 'check' ), 10 );
+		add_filter( 'cf7a_spam_check_chain', array( $this->native_filters['geoip'], 'check' ), 10 );
+		add_filter( 'cf7a_spam_check_chain', array( $this->native_filters['time_submission'], 'check' ), 10 );
+		add_filter( 'cf7a_spam_check_chain', array( $this->native_filters['bad_email_strings'], 'check' ), 10 );
+		add_filter( 'cf7a_spam_check_chain', array( $this->native_filters['user_agent'], 'check' ), 10 );
+		add_filter( 'cf7a_spam_check_chain', array( $this->native_filters['bad_words'], 'check' ), 10 );
+		add_filter( 'cf7a_spam_check_chain', array( $this->native_filters['dnsbl'], 'check' ), 10 );
+		add_filter( 'cf7a_spam_check_chain', array( $this->native_filters['honeypot'], 'check' ), 10 );
 
 		// Priority 20: Bayesian filter
-		add_filter( 'cf7a_spam_check_chain', array( new Filter_B8_Bayesian(), 'check' ), 20 );
+		add_filter( 'cf7a_spam_check_chain', array( $this->native_filters['b8'], 'check' ), 20 );
 	}
 
 	// ------------------------
@@ -148,6 +192,19 @@ class CF7_AntiSpam_Filters {
 		// -------------------------------------------------------------
 		// BUILD THE DATA OBJECT (Context)
 		// -------------------------------------------------------------
+
+		/**
+		 * Allow developers to disable specific native filters on a per-form basis.
+		 *
+		 * The callback receives the full $native_filters array (keyed by slug) and
+		 * the current form ID. Removing an entry (e.g. unset( $filters['b8'] ))
+		 * will cause that filter's check() method to return $spam_data unchanged.
+		 *
+		 * @param array $native_filters Associative array of filter instances keyed by slug.
+		 * @param int   $form_id        The ID of the CF7 form being submitted.
+		 */
+		$active_filters = apply_filters( 'cf7a_active_filters', $this->native_filters, $contact_form->id() );
+
 		$spam_data = array(
 			'submission'     => $submission,
 			'options'        => $options,
@@ -163,7 +220,8 @@ class CF7_AntiSpam_Filters {
 			'is_spam'        => $spam,
 			'reasons'        => array(),
 			'is_allowlisted' => false,
-		// Flag to stop processing
+			// Active filter map – used by each filter's check() for opt-out support.
+			'active_filters' => $active_filters,
 		);
 
 		if ( CF7ANTISPAM_DEBUG_EXTENDED ) {


### PR DESCRIPTION
Context: Following a discussion with Heiko, there is a need for a way to disable the B8 filter on specific forms. Instead of building a heavy UI tab for a developer-centric edge case, a hook is the smartest approach.

Action: Instead of creating a limited hook just for B8 (e.g., cf7a_enable_b8), we will introduce a much more flexible global filter in CF7_AntiSpam_Filters.php (around lines 54-78). This new filter will pass the entire array of active filters and the form ID.

Benefit: Developers and agencies will be able to use a simple unset() to selectively disable any filter (B8, GeoIP, Language, etc.) on a per-form basis.

Expected Implementation Example:

```php
add_filter( 'cf7a_active_filters', function( $filters, $form_id ) {
    // Disable B8 filter specifically for form ID 123
    if ( 123 == $form_id && isset( $filters['b8'] ) ) {
        unset( $filters['b8'] );
    }
    return $filters;
}, 10, 2 );
```