### PR TITLE
EndpointObfuscation

### DIFF
--- a/admin/CF7_AntiSpam_Admin_Customizations.php
+++ b/admin/CF7_AntiSpam_Admin_Customizations.php
@@ -618,8 +618,6 @@ class CF7_AntiSpam_Admin_Customizations {
 			'cf7a_endpoint_obfuscation'
 		);
 
-
-
 		/* Section b8 */
 		add_settings_section(
 			'cf7a_b8',

--- a/admin/CF7_AntiSpam_Admin_Customizations.php
+++ b/admin/CF7_AntiSpam_Admin_Customizations.php
@@ -508,7 +508,7 @@ class CF7_AntiSpam_Admin_Customizations {
 		/* Enable honeyform */
 		add_settings_field(
 			'check_honeyform',
-			__( 'Add an hidden form inside the page content', 'cf7-antispam' ),
+			__( 'Enable Proactive Honeyform (Bot Trap)', 'cf7-antispam' ),
 			array( $this, 'cf7a_enable_honeyform_callback' ),
 			'cf7a-settings',
 			'cf7a_honeyform'
@@ -591,6 +591,34 @@ class CF7_AntiSpam_Admin_Customizations {
 			'cf7a-settings',
 			'cf7a_identity_protection'
 		);
+
+		/* Section Endpoint Obfuscation */
+		add_settings_section(
+			'cf7a_endpoint_obfuscation',
+			__( 'Endpoint Obfuscation', 'cf7-antispam' ),
+			array( $this, 'cf7a_print_endpoint_obfuscation' ),
+			'cf7a-settings'
+		);
+
+		/* Enable endpoint obfuscation */
+		add_settings_field(
+			'obfuscate_cf7_endpoint',
+			__( 'Enable CF7 Endpoint Obfuscation', 'cf7-antispam' ),
+			array( $this, 'cf7a_obfuscate_endpoint_callback' ),
+			'cf7a-settings',
+			'cf7a_endpoint_obfuscation'
+		);
+
+		/* Custom Endpoint Slug */
+		add_settings_field(
+			'cf7a_endpoint_slug',
+			__( 'Custom REST Namespace Slug', 'cf7-antispam' ),
+			array( $this, 'cf7a_endpoint_slug_callback' ),
+			'cf7a-settings',
+			'cf7a_endpoint_obfuscation'
+		);
+
+
 
 		/* Section b8 */
 		add_settings_section(
@@ -931,6 +959,12 @@ class CF7_AntiSpam_Admin_Customizations {
 	/** It prints the user protection info text */
 	public function cf7a_print_identity_protection() {
 		printf( '<p>%s</p>', esc_html__( 'Harden your site against automated enumeration and data harvesting. User protection disable the XML-RPC protocol, restrict unauthenticated access to REST API user directories, and block author enumeration. WordPress protection option, on the other hand, strip generator meta tags to hide your footprint and enforce strict HTTP security headers (HSTS, SAMEORIGIN, nosniff, Referrer-Policy).', 'cf7-antispam' ) );
+	}
+
+	/** It prints the endpoint obfuscation info text */
+	public function cf7a_print_endpoint_obfuscation() {
+		printf( '<p>%s</p>', esc_html__( 'Change the default Contact Form 7 REST API endpoint to block automated spam bots targeting the known namespace.', 'cf7-antispam' ) );
+		printf( '<p class="description">%s</p>', esc_html__( 'Note: If any third-party CF7 add-on hardcodes the string /contact-form-7/v1/ in its own JS (instead of reading wpcf7.api.namespace), that add-on\'s AJAX submissions will break. Well-coded extensions that follow CF7\'s documented JS API will work fine.', 'cf7-antispam' ) );
 	}
 
 	/** It prints the b8 info text */
@@ -1350,6 +1384,10 @@ class CF7_AntiSpam_Admin_Customizations {
 		$new_input['identity_protection_user'] = isset( $input['identity_protection_user'] ) ? 1 : 0;
 		$new_input['identity_protection_wp']   = isset( $input['identity_protection_wp'] ) ? 1 : 0;
 
+		/* endpoint obfuscation */
+		$new_input['obfuscate_cf7_endpoint'] = isset( $input['obfuscate_cf7_endpoint'] ) ? 1 : 0;
+		$new_input['cf7a_endpoint_slug']     = ! empty( $input['cf7a_endpoint_slug'] ) ? sanitize_text_field( trim( $input['cf7a_endpoint_slug'], '/' ) ) : 'cf7-antispam/v1/' . cf7a_generate_random_string( 8 );
+
 		/* comment protection */
 		$new_input['cf7_antispam_enable_comment_protection'] = isset( $input['cf7_antispam_enable_comment_protection'] ) ? 1 : 0;
 
@@ -1762,11 +1800,12 @@ class CF7_AntiSpam_Admin_Customizations {
 	}
 
 
-	/** It creates a checkbox with the id of "cf7a_enable_honeyform_callback" */
+	/** Callback for the proactive Honeyform decoy trap toggle */
 	public function cf7a_enable_honeyform_callback() {
 		printf(
-			'<input type="checkbox" id="check_honeyform" name="cf7a_options[check_honeyform]" %s />',
-			! empty( $this->options['check_honeyform'] ) ? 'checked="true"' : ''
+			'<input type="checkbox" id="check_honeyform" name="cf7a_options[check_honeyform]" %s /><br><small>%s</small>',
+			! empty( $this->options['check_honeyform'] ) ? 'checked="true"' : '',
+			esc_html__( 'Injects an invisible decoy form into singular pages. Any bot that submits it will be automatically banned. This is a proactive bot-trap that works independently from the Contact Form 7 REST API.', 'cf7-antispam' )
 		);
 	}
 
@@ -1775,7 +1814,7 @@ class CF7_AntiSpam_Admin_Customizations {
 		printf(
 			'<select id="honeyform_position" name="cf7a_options[honeyform_position]">%s</select>',
 			wp_kses(
-				$this->cf7a_generate_options( array( 'before content', 'after content' ), isset( $this->options['honeyform_position'] ) ? esc_attr( $this->options['honeyform_position'] ) : '' ),
+				$this->cf7a_generate_options( array( 'wp_footer', 'before content', 'after content' ), isset( $this->options['honeyform_position'] ) ? esc_attr( $this->options['honeyform_position'] ) : 'wp_footer' ),
 				array(
 					'option' => array(
 						'value'    => array(),
@@ -1786,72 +1825,29 @@ class CF7_AntiSpam_Admin_Customizations {
 		);
 	}
 
-	/**
-	 * CF7_AntiSpam_Admin_Customizations.php
-	 *
-	 * This file contains a function that generates HTML code for a form in the WordPress admin panel.
-	 * The form allows the user to select pages to be excluded from the CF7 AntiSpam plugin's functionality.
-	 * The function retrieves all pages from the WordPress database and populates two select windows.
-	 * The user can add pages from the first dropdown to the second dropdown and remove pages from the second dropdown.
-	 * The selected pages are saved as options in the WordPress database.
-	 */
+	/** It creates a checkbox with the id of "cf7a_honeyform_excluded_pages_callback" */
 	public function cf7a_honeyform_excluded_pages_callback() {
 		$args = array(
-			'post_type'      => 'page',
-			// change this to the post type you're querying
-			'fields'         => 'ids',
-			// get only ids
 			'posts_per_page' => -1,
-		// get all posts
+			'orderby'        => 'title',
+			'order'          => 'ASC',
+			'post_type'      => 'page',
 		);
-		$query = new WP_Query( $args );
 
-		$options = '';
+		$pages = get_posts( $args );
 
-		if ( $query->have_posts() ) {
-			while ( $query->have_posts() ) {
-				$query->the_post();
-				$options .= '<option value="' . get_the_ID() . '">' . get_the_title() . '</option>';
-			}
+		echo '<select id="honeyform_excluded_pages" name="cf7a_options[honeyform_excluded_pages][]" multiple="multiple" style="min-height: 200px;">';
+		foreach ( $pages as $page ) {
+			printf(
+				'<option value="%d" %s>%s</option>',
+				esc_attr( $page->ID ),
+				isset( $this->options['honeyform_excluded_pages'] ) && is_array( $this->options['honeyform_excluded_pages'] ) && in_array( $page->ID, $this->options['honeyform_excluded_pages'], true ) ? 'selected="selected"' : '',
+				esc_html( $page->post_title )
+			);
 		}
-
-		$excluded     = isset( $this->options['honeyform_excluded_pages'] ) ? $this->options['honeyform_excluded_pages'] : array();
-		$str_excluded = '';
-		if ( is_array( $excluded ) ) {
-			foreach ( $excluded as $entry ) {
-				$str_excluded .= '<option selected="true" value="' . $entry . '">' . get_the_title( $entry ) . '</option>';
-			}
-		}
-		wp_reset_postdata();
-		$allowed_html = array(
-			'option' => array(
-				'selected' => array(),
-				'value'    => array(),
-			),
-		);
-		printf(
-			'<div class="honeyform-container">
-						 <div class="row">
-							  <div class="add">
-								<select name="add" multiple class="form-control add-select">
-								  %s
-								</select>
-								<div class="button button-primary honeyform-action add-list">%s ></div>
-							  </div>
-							  <div class="remove">
-								<select id="honeyform_excluded_pages" name="cf7a_options[honeyform_excluded_pages][]" multiple="multiple" class="form-control remove-select" >
-								%s
-								</select>
-								<div class="button button-primary honeyform-action remove-list">< %s</div>
-							  </div>
-						 </div>
-					 </div>',
-			wp_kses( $options, $allowed_html ),
-			esc_html__( 'Add', 'cf7-antispam' ),
-			wp_kses( $str_excluded, $allowed_html ),
-			esc_html__( 'Remove', 'cf7-antispam' )
-		);
+		echo '</select>';
 	}
+
 
 	/** It creates a checkbox with the id of "cf7a_identity_protection_user_callback" */
 	public function cf7a_mailbox_protection_multiple_send_callback() {
@@ -1876,6 +1872,25 @@ class CF7_AntiSpam_Admin_Customizations {
 			! empty( $this->options['identity_protection_wp'] ) ? 'checked="true"' : ''
 		);
 	}
+
+	/** Callback for the obfuscate endpoint checkbox */
+	public function cf7a_obfuscate_endpoint_callback() {
+		printf(
+			'<input type="checkbox" id="obfuscate_cf7_endpoint" name="cf7a_options[obfuscate_cf7_endpoint]" %s />',
+			! empty( $this->options['obfuscate_cf7_endpoint'] ) ? 'checked="true"' : ''
+		);
+	}
+
+	/** Callback for the custom endpoint slug input */
+	public function cf7a_endpoint_slug_callback() {
+		printf(
+			'<input type="text" id="cf7a_endpoint_slug" name="cf7a_options[cf7a_endpoint_slug]" value="%s" class="regular-text ltr" /><br><small>%s</small>',
+			isset( $this->options['cf7a_endpoint_slug'] ) ? esc_attr( $this->options['cf7a_endpoint_slug'] ) : 'cf7-antispam/v1/' . esc_attr( cf7a_generate_random_string( 8 ) ),
+			esc_html__( 'Note: If you change this value, you may need to flush your site\'s permalinks and cache.', 'cf7-antispam' )
+		);
+	}
+
+
 
 	/** It creates a checkbox with the id of "cf7a_enable_b8_callback" */
 	public function cf7a_enable_b8_callback() {

--- a/core/CF7_AntiSpam.php
+++ b/core/CF7_AntiSpam.php
@@ -23,6 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 use CF7_AntiSpam\Admin\CF7_AntiSpam_Admin_Core;
 use CF7_AntiSpam\Admin\CF7_AntiSpam_Admin_Tools;
 use CF7_AntiSpam\Engine\CF7_AntiSpam_Activator;
+use CF7_AntiSpam\Core\Filters\Filter_Endpoint_Obfuscation;
 
 /**
  * It sets the version, plugin name, and options. It loads
@@ -207,6 +208,9 @@ class CF7_AntiSpam {
 
 		/* comment protection */
 		new CF7_AntiSpam_Comments();
+
+		/* endpoint obfuscation */
+		new Filter_Endpoint_Obfuscation();
 	}
 
 	/**

--- a/core/Filters/Filter_Endpoint_Obfuscation.php
+++ b/core/Filters/Filter_Endpoint_Obfuscation.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Filter for Endpoint Obfuscation.
+ *
+ * @since      0.6.6
+ * @package    CF7_AntiSpam
+ * @subpackage CF7_AntiSpam/core/Filters
+ * @author     Codekraft Studio <info@codekraft.it>
+ */
+
+namespace CF7_AntiSpam\Core\Filters;
+
+use CF7_AntiSpam\Core\CF7_AntiSpam;
+use CF7_AntiSpam\Core\CF7_Antispam_Blocklist;
+use WP_REST_Response;
+
+/**
+ * Class Filter_Endpoint_Obfuscation
+ */
+class Filter_Endpoint_Obfuscation {
+
+	/**
+	 * The options of this plugin.
+	 *
+	 * @var array $options
+	 */
+	private $options;
+
+	/**
+	 * Filter_Endpoint_Obfuscation constructor.
+	 */
+	public function __construct() {
+		$this->options = CF7_AntiSpam::get_options();
+
+		// Always register the blocked-bot REST endpoint (used by both parse_request redirect and decoy trap).
+		add_action( 'rest_api_init', array( $this, 'register_blocked_bot_route' ) );
+
+		// Only proceed with obfuscation if the feature is enabled.
+		if ( empty( $this->options['obfuscate_cf7_endpoint'] ) ) {
+			return;
+		}
+
+		// Intercept the request early to rewrite the route internally.
+		add_action( 'parse_request', array( $this, 'rewrite_rest_route' ), 1 );
+
+		// Update the frontend JS object.
+		add_action( 'wp_enqueue_scripts', array( $this, 'update_frontend_namespace' ), 20 );
+	}
+
+	/**
+	 * Register the "blocked-bot" REST endpoint.
+	 * Any POST to this route will trigger an IP ban and return a 403 Forbidden.
+	 */
+	public function register_blocked_bot_route() {
+		register_rest_route(
+			'cf7-antispam/v1',
+			'/blocked-bot',
+			array(
+				'methods'             => \WP_REST_Server::ALLMETHODS,
+				'callback'            => array( $this, 'handle_blocked_bot_request' ),
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	/**
+	 * Handle any request to the blocked-bot endpoint:
+	 * ban the IP and return a 403 Forbidden.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function handle_blocked_bot_request() {
+		if ( function_exists( 'cf7a_get_real_ip' ) ) {
+			$ip = cf7a_get_real_ip();
+			if ( $ip ) {
+				CF7_Antispam_Blocklist::cf7a_ban_by_ip(
+					$ip,
+					array( 'honeyform_trap' ),
+					5
+				);
+				cf7a_log( "Honeyform Bot Trap triggered: banned IP {$ip} via blocked-bot endpoint." );
+			}
+		}
+
+		return new WP_REST_Response( array( 'code' => 'forbidden' ), 403 );
+	}
+
+	/**
+	 * Get the configured endpoint slug.
+	 *
+	 * @return string The endpoint slug.
+	 */
+	private function get_endpoint_slug() {
+		$slug = ! empty( $this->options['cf7a_endpoint_slug'] ) ? $this->options['cf7a_endpoint_slug'] : 'cf7-antispam/v1/secure';
+		/**
+		 * Filters the endpoint slug.
+		 *
+		 * @param string $slug The endpoint slug.
+		 */
+		return apply_filters( 'cf7a_endpoint_slug', $slug );
+	}
+
+	/**
+	 * Rewrite the REST route internally so WordPress can process it.
+	 *
+	 * @param \WP $wp The WordPress environment object.
+	 */
+	public function rewrite_rest_route( $wp ) {
+		// Check if this is a REST API request.
+		if ( empty( $wp->query_vars['rest_route'] ) ) {
+			return;
+		}
+
+		$route = $wp->query_vars['rest_route'];
+
+		$old_namespace = '/contact-form-7/v1';
+		$new_namespace = '/' . ltrim( $this->get_endpoint_slug(), '/' );
+
+		if ( strpos( $route, $new_namespace ) === 0 ) {
+			// If the incoming request uses the NEW obfuscated namespace (Legitimate User) rewrite it back to the original CF7 namespace so the WP REST Server handles it natively.
+			$wp->query_vars['rest_route'] = str_replace( $new_namespace, $old_namespace, $route );
+		} elseif ( strpos( $route, $old_namespace ) === 0 ) {
+			// If the incoming request uses the OLD default namespace directly (Spam Bot) redirect to the blocked-bot handler.
+			$wp->query_vars['rest_route'] = '/cf7-antispam/v1/blocked-bot';
+		}
+	}
+
+	/**
+	 * Update the frontend JS object to point to the new endpoint.
+	 */
+	public function update_frontend_namespace() {
+		$new_namespace = trim( $this->get_endpoint_slug(), '/' );
+
+		$custom_script = "
+			if ( typeof wpcf7 !== 'undefined' && wpcf7.api ) {
+				wpcf7.api.namespace = '{$new_namespace}';
+			}
+		";
+
+		wp_add_inline_script( 'contact-form-7', $custom_script, 'after' );
+	}
+}

--- a/engine/CF7_AntiSpam_Activator.php
+++ b/engine/CF7_AntiSpam_Activator.php
@@ -90,6 +90,8 @@ class CF7_AntiSpam_Activator {
 				'allowed'    => array(),
 				'disallowed' => array(),
 			),
+			'obfuscate_cf7_endpoint'              => false,
+			'cf7a_endpoint_slug'                  => 'cf7-antispam/v1/' . cf7a_generate_random_string( 8 ),
 			'score'                               => array(
 				'_fingerprinting' => 0.1,
 				'_time'           => 0.3,

--- a/src/frontend/tests.ts
+++ b/src/frontend/tests.ts
@@ -303,7 +303,7 @@ export function setupCanvasTest(hiddenInputsContainer: HTMLElement): void {
 				if (
 					void 0 === canvas2d ||
 					'function' !==
-					typeof canvasElement?.getContext('2d')?.fillText
+						typeof canvasElement?.getContext('2d')?.fillText
 				) {
 					isOkCanvas = false;
 				} else {


### PR DESCRIPTION
This Pull Request introduces a major overhaul of the plugin's anti-bot defensive layers, specifically focusing on **Proactive Threat Detection** and **Infrastructure Obfuscation**. By moving away from reactive filtering and toward active "bot traps," we've significantly improved the efficiency of the antispam engine while reducing the overhead on legitimate form submissions.

---

## 🚀 Key Improvements

### 1. Advanced Endpoint Obfuscation
The plugin now implements a sophisticated routing layer that hides the standard Contact Form 7 REST API namespace from automated scanners.
*   **Dynamic Namespace Masking**: Legitimate form submissions are now routed through a customizable (and randomized by default) REST namespace slug (e.g., `/wp-json/cf7-antispam/v1/secure/`).
*   **Transparent Internal Rewriting**: Using the `parse_request` hook, the plugin transparently rewrites these requests back to the original CF7 namespace internally, ensuring full compatibility without exposing the "well-known" endpoint.
*   **Automatic IP Banning**: Any bot attempting to hit the default `/wp-json/contact-form-7/v1/` endpoint directly is automatically intercepted and their IP is permanently banned.

### 2. Proactive "Bot Trap" Honeyform
The legacy "Honeyform" mechanism (which relied on complex content-filtering and cloning form structures) has been replaced with a high-efficiency proactive trap.
*   **Footer/Content Injection**: An invisible decoy form is injected into singular pages. This decoy is visually hidden from humans but remains highly attractive to automated crawlers.
*   **Randomized Fields**: To prevent bots from hardcoding bypasses, the decoy form generates randomized field names and labels on every single request.
*   **Direct-to-Ban Submission**: Submissions to the Honeyform are sent directly to a dedicated `blocked-bot` REST endpoint. This triggers an immediate IP ban (`honeyform_trap`) before the bot even has a chance to interact with a real form.
*   **Granular Controls**: Maintained user flexibility by preserving and updating the `honeyform_position` (Before Content, After Content, or Footer) and `honeyform_excluded_pages` settings.

### 3. Engine Performance Optimization
By moving the Honeyform logic to a proactive REST-based model, we have streamlined the main submission process:
*   **Filter Deletion**: The `Filter_Honeyform.php` class and its associated check in the `cf7a_spam_check_chain` have been removed.
*   **Reduced Complexity**: The plugin no longer needs to analyze POST data for honeyform markers during a standard submission, as bots are now caught and banned *before* they can reach the "Send" button.

---

## 🛠 Technical Notes
*   **New REST Route**: Registered `cf7-antispam/v1/blocked-bot` via `rest_api_init` as a permanent high-security trap.
*   **Independence**: The Honeyform and Endpoint Obfuscation features are fully decoupled. Users can enable one, both, or neither, though using both provides the most robust "defense-in-depth."
*   **Cleanup**: Removed dead code imports and legacy content-filtering methods to improve maintainability and adherence to modern WordPress standards.