### PR TITLE
Update honeypot input autocomplete and enable style replacements

### DIFF
--- a/core/CF7_AntiSpam_Frontend.php
+++ b/core/CF7_AntiSpam_Frontend.php
@@ -238,7 +238,7 @@ class CF7_AntiSpam_Frontend {
 			$template = wp_kses(
 				apply_filters(
 					'cf7a_honeypot_input_template',
-					'<input type="text" name="{name}" value="" autocomplete="off" class="{class}" aria-label="{aria_label}" aria-hidden="true" tabindex="-1" />',
+					'<input type="text" name="{name}" value="" autocomplete="new-password" class="{class}" aria-label="{aria_label}" aria-hidden="true" tabindex="-1" />',
 					$replacements
 				),
 				array(
@@ -248,6 +248,7 @@ class CF7_AntiSpam_Frontend {
 						'value'        => array(),
 						'autocomplete' => array(),
 						'class'        => array(),
+						'style'        => array(),
 						'aria-label'   => array(),
 						'aria-hidden'  => array(),
 						'tabindex'     => array(),

--- a/core/CF7_AntiSpam_Frontend.php
+++ b/core/CF7_AntiSpam_Frontend.php
@@ -230,10 +230,14 @@ class CF7_AntiSpam_Frontend {
 			/**
 			 * Filters the honeypot input template string.
 			 *
-			 * @since 0.6.0
+			 * NOTE: Keep autocomplete="new-password". Do NOT revert to "off".
+			 * Modern browsers (Chrome) ignore "off" and trigger autofill,
+			 * which breaks honeypot validation.
 			 *
 			 * @param string $template     The HTML template.
 			 * @param array  $replacements The data available for replacement.
+			 *
+			 *@since 0.6.0
 			 */
 			$template = wp_kses(
 				apply_filters(


### PR DESCRIPTION
Updated the autocomplete attribute for honeypot fields from off to new-password.

Modern browsers (specifically Chrome) ignore autocomplete="off" for certain form inputs, leading to unwanted autofill behavior that triggers honeypot validation errors. Using new-password is the current standard workaround to effectively signal the browser to refrain from auto-filling these hidden fields.